### PR TITLE
一些更新

### DIFF
--- a/api/presenters.py
+++ b/api/presenters.py
@@ -5,7 +5,6 @@ import requests
 import subprocess as sub
 import gcoin as gcoin_lib
 
-from flask import jsonify
 from api.models import HistoryTx, TxFactory
 from bank import Bank
 from config import AUTHORIZED_BANKS
@@ -27,6 +26,22 @@ class BankPresenter(object):
             bank = Bank.manager.get_bank_by_id(self.bank.bank_id)
             banks.append(bank.as_dict(model=self.model))
         return banks
+
+
+class BatchSettlePresenter(object):
+
+    def batch_settle(self):
+        central_bank = Bank.manager.get_central_bank()
+        txid = central_bank.contract_batch_settle()
+        return txid
+
+
+class SmartContractMintPresenter(object):
+
+    def mint(self, bank_id, amount):
+        bank = Bank.manager.get_bank_by_id(bank_id)
+        txid = bank.contract_mint(amount)
+        return txid
 
 
 class BaseTxPresenter(object):
@@ -67,11 +82,10 @@ class TransactionPresenter(BaseTxPresenter):
 
     def query(self, trigger_bank, receive_bank, status):
         txs = self.tx_db.get_txs(trigger_bank, receive_bank, status)
-        return sorted(txs, key=lambda k: k['created_time'], reverse=True)
+        return txs
 
     def remove_all(self):
         self.tx_db.remove_all()
-        return jsonify(data={'message': 'Deleted!'})
 
 
 class TxStateChangePresenter(BaseTxPresenter):

--- a/api/presenters.py
+++ b/api/presenters.py
@@ -82,7 +82,7 @@ class TransactionPresenter(BaseTxPresenter):
 
     def query(self, trigger_bank, receive_bank, status):
         txs = self.tx_db.get_txs(trigger_bank, receive_bank, status)
-        return txs
+        return sorted(txs, key=lambda k: k['created_time'], reverse=True)
 
     def remove_all(self):
         self.tx_db.remove_all()
@@ -143,7 +143,7 @@ class TxStateChangePresenter(BaseTxPresenter):
         try:
             tx_id = bank_from.send_to(bank_to, amount)
         except Exception:
-            tx_data = self.reject(tx_data['key'])
+            tx_data = self.destroy(tx_data['key'])
             return tx_data, False
         else:
             tx_data['tx_id'] = tx_id

--- a/api/smart_contract_views.py
+++ b/api/smart_contract_views.py
@@ -1,4 +1,5 @@
-from flask import Blueprint
+from flask import Blueprint, jsonify, request
+from presenters import BatchSettlePresenter, SmartContractMintPresenter
 from common_views_func import (
     query, ready, accept, reject, notify, banks
 )
@@ -13,7 +14,26 @@ def index():
     return 'Smart Contract!'
 
 
-@smart_contract.route('/<bank_id>/banks')
+@smart_contract.route('/<bank_id>/batch_settle', methods=['POST'])
+def batch_settle(bank_id):
+    if bank_id == 'TCH':
+        presenter = BatchSettlePresenter()
+        txid = presenter.batch_settle()
+        return jsonify(data=txid)
+    return jsonify({'error': 'unauthorized'})
+
+
+@smart_contract.route('/<bank_id>/mint', methods=['POST'])
+def mint(bank_id):
+    if bank_id == 'TCH':
+        data = request.json
+        presenter = SmartContractMintPresenter()
+        txid = presenter.mint(data['bank'], data['amount'])
+        return jsonify(data=txid)
+    return jsonify({'error': 'unauthorized'})
+
+
+@smart_contract.route('/<bank_id>/banks', methods=['GET'])
 def smart_contract_banks(bank_id):
     return banks(bank_id, SMART_CONTRACT_MODEL)
 

--- a/bank.py
+++ b/bank.py
@@ -17,13 +17,16 @@ class BankManager(object):
 
     def __init__(self):
         self.bank_list = BANK_LIST
-        self.bank_list.append('central_bank')
         self.bank_cache = {}
         self._central_bank = None
         self.tx_pool = []
 
     def get_bank_by_id(self, bank_id):
-        if bank_id not in self.bank_list:
+        if (
+            bank_id not in self.bank_list and
+            bank_id != 'TCH' and
+            bank_id != 'central_bank'
+        ):
             bank_id = 'EA0'
 
         if bank_id not in self.bank_cache:
@@ -34,6 +37,11 @@ class BankManager(object):
     def get_central_bank(self):
         if not self._central_bank:
             self._central_bank = Bank('central_bank')
+        return self._central_bank
+
+    def get_tch(self):
+        if not self._central_bank:
+            self._central_bank = Bank('tch')
         return self._central_bank
 
 

--- a/bank.py
+++ b/bank.py
@@ -8,7 +8,7 @@ from config import (
 from gcoin_presenter import GcoinPresenter
 from smart_contract.utils import (
     create_trade_data, create_deploy_data,
-    create_mint_data, create_clear_queue_data,
+    create_mint_data, create_batch_settle_data,
     create_reset_data, DEFAULT_CONTRACT_ID
 )
 
@@ -139,9 +139,9 @@ class Bank(object):
                                           1, 1, contract_data)
         return self._sign_and_send_tx(raw_tx)
 
-    def contract_clear_queue(self, comment='',
-                             contract_id=DEFAULT_CONTRACT_ID):
-        contract_data = create_clear_queue_data(comment, contract_id)
+    def contract_batch_settle(self, comment='',
+                              contract_id=DEFAULT_CONTRACT_ID):
+        contract_data = create_batch_settle_data(comment, contract_id)
         raw_tx = self.gcoin.create_raw_tx(self.address, self.address,
                                           1, 1, contract_data)
         return self._sign_and_send_tx(raw_tx)

--- a/config.py
+++ b/config.py
@@ -4,6 +4,8 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 CONTRACT_SERVER_URL = 'http://ach.csie.org:9999'
 
+CLEAN_COLOR = 2
+
 SMART_CONTRACT_PATH = os.path.join(BASE_DIR, 'smart_contract')
 
 DB_PATH = os.path.join(BASE_DIR, 'db')
@@ -21,16 +23,16 @@ AUTHORIZED_BANKS = ['TCH']
 
 BANK_LIST = [
     # banks for demo
-    'X', 'Y', 'Z', 'TCH',
+    'X', 'Y', 'Z'
     # banks from history data
-    '6AB', 'A28', '46E', 'DD3', '822', 'CCC', '219',
-    '18C', '170', 'B63', '62F', '5E0', '666', '519',
-    'BA4', '5BD', '682', 'E07', 'B31', '0B1', 'FCB',
-    'B89', '101', 'EDB', 'E75', '75D', 'A0D', '22D',
-    'AB5', 'A1D', 'F73', 'C45', '481', '49A', 'EE0',
-    '269', '7BA', '48C', 'E0C', 'CE3', '8DA', '552',
-    '1F6', 'B30', '6D4', 'FB4', '4AD', '940', '838',
-    'E15', 'F8E', '717', 'C72', '882', 'EA0'
+    # '6AB', 'A28', '46E', 'DD3', '822', 'CCC', '219',
+    # '18C', '170', 'B63', '62F', '5E0', '666', '519',
+    # 'BA4', '5BD', '682', 'E07', 'B31', '0B1', 'FCB',
+    # 'B89', '101', 'EDB', 'E75', '75D', 'A0D', '22D',
+    # 'AB5', 'A1D', 'F73', 'C45', '481', '49A', 'EE0',
+    # '269', '7BA', '48C', 'E0C', 'CE3', '8DA', '552',
+    # '1F6', 'B30', '6D4', 'FB4', '4AD', '940', '838',
+    # 'E15', 'F8E', '717', 'C72', '882', 'EA0'
 ]
 
 BANK_URL = {
@@ -39,8 +41,6 @@ BANK_URL = {
     'Z': 'http://{}:{}'.format('', ''),
     'TCH': 'http://{}:{}'.format('', ''),
 }
-
-CLEAN_COLOR = 2
 
 VALID_DATE_LIST = [
     '01050601', '01050602', '01050603', '01050604',

--- a/smart_contract/ACH_contract.py
+++ b/smart_contract/ACH_contract.py
@@ -2,14 +2,14 @@ BANK_LIST = [
     # banks for demo
     'X', 'Y', 'Z', 'TCH',
     # banks from history data
-    '6AB', 'A28', '46E', 'DD3', '822', 'CCC', '219',
-    '18C', '170', 'B63', '62F', '5E0', '666', '519',
-    'BA4', '5BD', '682', 'E07', 'B31', '0B1', 'FCB',
-    'B89', '101', 'EDB', 'E75', '75D', 'A0D', '22D',
-    'AB5', 'A1D', 'F73', 'C45', '481', '49A', 'EE0',
-    '269', '7BA', '48C', 'E0C', 'CE3', '8DA', '552',
-    '1F6', 'B30', '6D4', 'FB4', '4AD', '940', '838',
-    'E15', 'F8E', '717', 'C72', '882', 'EA0'
+    # '6AB', 'A28', '46E', 'DD3', '822', 'CCC', '219',
+    # '18C', '170', 'B63', '62F', '5E0', '666', '519',
+    # 'BA4', '5BD', '682', 'E07', 'B31', '0B1', 'FCB',
+    # 'B89', '101', 'EDB', 'E75', '75D', 'A0D', '22D',
+    # 'AB5', 'A1D', 'F73', 'C45', '481', '49A', 'EE0',
+    # '269', '7BA', '48C', 'E0C', 'CE3', '8DA', '552',
+    # '1F6', 'B30', '6D4', 'FB4', '4AD', '940', '838',
+    # 'E15', 'F8E', '717', 'C72', '882', 'EA0'
 ]
 
 
@@ -17,10 +17,21 @@ class Contract(object):
 
     def init_state(self):
         state = {
-            'queue': [],
+            'unsettled_flow': {},
             'unsettled_balance': {b: 0 for b in BANK_LIST},
             'balance': {b: 0 for b in BANK_LIST}
         }
+
+        for i in range(len(BANK_LIST)):
+            for j in range(i+1, len(BANK_LIST)):
+                state['unsettled_flow'][BANK_LIST[i]] = {}
+                state['unsettled_flow'][BANK_LIST[j]] = {}
+
+        for i in range(len(BANK_LIST)):
+            for j in range(i+1, len(BANK_LIST)):
+                state['unsettled_flow'][BANK_LIST[i]][BANK_LIST[j]] = 0
+                state['unsettled_flow'][BANK_LIST[j]][BANK_LIST[i]] = 0
+
         return state
 
     def trade(self, data, state):
@@ -35,7 +46,15 @@ class Contract(object):
         else:
             state['unsettled_balance'][from_address] -= amount
             state['unsettled_balance'][to_address] += amount
-            state['queue'].append(data)
+
+            reverse_flow = state['unsettled_flow'][to_address][from_address]
+            flow = amount - reverse_flow
+            if flow > 0:
+                state['unsettled_flow'][from_address][to_address] = flow
+                state['unsettled_flow'][to_address][from_address] = 0
+            else:
+                state['unsettled_flow'][from_address][to_address] = 0
+                state['unsettled_flow'][to_address][from_address] = -1 * flow
         return state
 
     def mint(self, data, state):
@@ -45,24 +64,70 @@ class Contract(object):
         state['balance'][address] += amount
         return state
 
-    def clear_queue(self, data, state):
+    def batch_settle(self, data, state):
+        import copy
+
         state = dict(state)
-        remaining_queue = []
-        for data in state['queue']:
-            from_address = data['from_address']
-            to_address = data['to_address']
-            amount = data['amount']
+        count = 0
+        while True:
+            old_state = copy.deepcopy(state)
+            for bank_source in BANK_LIST:
+                if (state['balance'][bank_source] > 0 and
+                        state['unsettled_balance'][bank_source] < 0):
+                    balance = state['balance'][bank_source]
+                    for bank_to in BANK_LIST:
+                        if bank_to == bank_source:
+                            continue
 
-            if state['balance'][from_address] >= amount:
-                state['unsettled_balance'][from_address] += amount
-                state['unsettled_balance'][to_address] -= amount
-                state['balance'][from_address] -= amount
-                state['balance'][to_address] += amount
-            else:
-                remaining_queue.append(data)
+                        if state['unsettled_flow'][bank_source][bank_to] > 0:
+                            flow = state['unsettled_flow'][bank_source][bank_to]
+                            diff = min(flow, balance)
+                            state['unsettled_flow'][bank_source][bank_to] -= diff
+                            state['unsettled_balance'][bank_source] += diff
+                            state['unsettled_balance'][bank_to] -= diff
+                            state['balance'][bank_source] -= diff
+                            state['balance'][bank_to] += diff
 
-        state['queue'] = remaining_queue
+                        if state['balance'][bank_source] == 0:
+                            break
+            if state == old_state:
+                break
+            count += 1
         return state
 
     def reset(self, data, state):
         return self.init_state()
+
+
+def test(with_assert=True):
+    import json
+
+    contract = Contract()
+    state = contract.init_state()
+
+    trade_data = {'from_address': 'X', 'to_address': 'Y', 'amount': 5}
+    state = contract.trade(trade_data, state)
+    trade_data = {'from_address': 'Y', 'to_address': 'Z', 'amount': 3}
+    state = contract.trade(trade_data, state)
+    trade_data = {'from_address': 'Z', 'to_address': 'X', 'amount': 2}
+    state = contract.trade(trade_data, state)
+    if with_assert:
+        assert state['unsettled_balance']['X'] == -3, 'wrong unsettled_balance'
+        assert state['unsettled_balance']['Y'] == 2, 'wrong unsettled_balance'
+        assert state['unsettled_balance']['Z'] == 1, 'wrong unsettled_balance'
+
+    mint_data = {'address': 'X', 'amount': 3}
+    state = contract.mint(mint_data, state)
+    if with_assert:
+        assert state['balance']['X'] == 3, '`mint` might not succeed'
+
+    state = contract.batch_settle({}, state)
+    if with_assert:
+        assert state['balance']['X'] == 0, '`batch_settle` might not succeed'
+        assert state['balance']['Y'] == 2, '`batch_settle` might not succeed'
+        assert state['balance']['Z'] == 1, '`batch_settle` might not succeed'
+        assert state['unsettled_balance']['X'] == 0, '`batch_settle` might not succeed'
+        assert state['unsettled_balance']['Y'] == 0, '`batch_settle` might not succeed'
+        assert state['unsettled_balance']['Z'] == 0, '`batch_settle` might not succeed'
+        assert json.dumps(state)
+    return state

--- a/smart_contract/utils.py
+++ b/smart_contract/utils.py
@@ -3,7 +3,7 @@ import json
 from config import SMART_CONTRACT_PATH
 
 
-DEFAULT_CONTRACT_ID = 2
+DEFAULT_CONTRACT_ID = 4
 
 
 def create_reset_data(contract_id, comment=''):
@@ -50,11 +50,11 @@ def create_mint_data(address, amount, comment='',
     return json.dumps(contract_data)
 
 
-def create_clear_queue_data(comment='', contract_id=DEFAULT_CONTRACT_ID):
+def create_batch_settle_data(comment='', contract_id=DEFAULT_CONTRACT_ID):
     contract_data = {
         'type': 'RUN_CONTRACT',
         'contract_id': contract_id,
-        'function': 'clear_queue',
+        'function': 'batch_settle',
         'data': {},
         'comment': comment,
     }


### PR DESCRIPTION
1. 更新 contract code 的清算機制:
舊的寫法，直接把無法清算的 tx 放進 queue，但之後再處理時，還是需要匯入超越 tx 帳面的金額，該筆 tx 才會被清算掉，即使有一筆反向的 tx 可以沖掉也不會被處理。
新寫法，不把 tx 放進 queue，相對的，記錄每個銀行之間誰應該給誰多少錢，然後當發動清算時，會嘗試把互相欠錢的 flow 互相抵消。新寫法是如果有銀行有正的 balance 且是有負的 unsettled_balance （尚未被清算的欠款），就會啟動抵銷機制，把他的 balance 移轉到他所欠錢的那一方。然後不斷重複次動作，直到 state 不再改變為止。

2. 新增兩個 api：mint 和 batch_settle